### PR TITLE
Reduce memory usage when consuming tasks

### DIFF
--- a/feeds/fetcher.go
+++ b/feeds/fetcher.go
@@ -1,0 +1,87 @@
+package feeds
+
+import (
+	"github.com/mlposey/z4/proto"
+	"github.com/mlposey/z4/storage"
+	"github.com/mlposey/z4/telemetry"
+	"github.com/segmentio/ksuid"
+	"go.uber.org/zap"
+	"io"
+	"time"
+)
+
+// undeliveredTaskFetcher fetches tasks that have not been delivered to clients.
+type undeliveredTaskFetcher struct {
+	Tasks     *storage.TaskStore
+	StartID   string
+	Namespace string
+}
+
+func (utf *undeliveredTaskFetcher) Process(handle func(task *proto.Task) error) error {
+	it := storage.NewTaskIterator(utf.Tasks.Client, storage.TaskRange{
+		Namespace: utf.Namespace,
+		StartID:   utf.StartID,
+		EndID:     storage.NewTaskID(time.Now()),
+	})
+
+	first, err := it.Peek()
+	if err != nil {
+		if err == io.EOF {
+			return nil
+		}
+		return err
+	}
+
+	if first.GetId() == utf.StartID {
+		// Skip last delivered tasks because we already delivered it :)
+		it.Next()
+	}
+	return it.ForEach(handle)
+}
+
+// undeliveredTaskFetcher fetches tasks that were delivered to clients but never acknowledged.
+type deliveredTaskFetcher struct {
+	Tasks           *storage.TaskStore
+	LastDeliveredID string
+	Namespace       string
+	AckDeadline     time.Duration
+	watermark       time.Time
+	lastDelivery    time.Time
+}
+
+func (dtf *deliveredTaskFetcher) Process(handle func(task *proto.Task) error) error {
+	startTask, err := ksuid.Parse(dtf.LastDeliveredID)
+	if err != nil {
+		return err
+	}
+	dtf.lastDelivery = startTask.Time()
+
+	dtf.watermark = time.Now().Add(-dtf.AckDeadline)
+	it := storage.NewTaskIterator(dtf.Tasks.Client, storage.TaskRange{
+		Namespace: dtf.Namespace,
+		StartID:   storage.NewTaskID(ksuid.Nil.Time()),
+		EndID:     storage.NewTaskID(dtf.watermark),
+	})
+
+	return it.ForEach(func(task *proto.Task) error {
+		if dtf.retryTask(task) {
+			if err := handle(task); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (dtf *deliveredTaskFetcher) retryTask(task *proto.Task) bool {
+	ts, err := ksuid.Parse(task.GetId())
+	if err != nil {
+		telemetry.Logger.Error("failed to parse task id",
+			zap.Error(err))
+		return false
+	}
+
+	lastRetry := task.GetLastRetry().AsTime()
+	return !ts.Time().After(dtf.lastDelivery) &&
+		(lastRetry.IsZero() || lastRetry.Add(dtf.AckDeadline).Before(dtf.watermark))
+}

--- a/server/cluster/fsm.go
+++ b/server/cluster/fsm.go
@@ -18,6 +18,7 @@ type stateMachine struct {
 }
 
 func newFSM(db *badger.DB, ts *storage.TaskStore) *stateMachine {
+	// TODO: Do not pass a *badger.DB directly. Create a new type.
 	return &stateMachine{
 		db: db,
 		ts: ts,

--- a/storage/badger.go
+++ b/storage/badger.go
@@ -231,7 +231,22 @@ func (ti *TaskIterator) Next() (*proto.Task, error) {
 	if !ti.it.Valid() {
 		return nil, io.EOF
 	}
-	defer ti.it.Next()
+
+	task, err := ti.peek(true)
+	if err != io.EOF {
+		ti.it.Next()
+	}
+	return task, err
+}
+
+func (ti *TaskIterator) Peek() (*proto.Task, error) {
+	return ti.peek(false)
+}
+
+func (ti *TaskIterator) peek(skipCheck bool) (*proto.Task, error) {
+	if skipCheck || !ti.it.Valid() {
+		return nil, io.EOF
+	}
 
 	item := ti.it.Item()
 	if bytes.Compare(item.Key(), ti.end) > 0 {

--- a/storage/badger.go
+++ b/storage/badger.go
@@ -244,7 +244,7 @@ func (ti *TaskIterator) Peek() (*proto.Task, error) {
 }
 
 func (ti *TaskIterator) peek(skipCheck bool) (*proto.Task, error) {
-	if skipCheck || !ti.it.Valid() {
+	if !skipCheck && !ti.it.Valid() {
 		return nil, io.EOF
 	}
 


### PR DESCRIPTION
Prior to these changes, load tests showed that the GetTaskStream rpc could not support large task sets. This was due to logic that buffered tasks in memory and then pushed them to clients. Now, tasks are streamed to clients and the buffering has been almost completely removed.