### PR TITLE
Refactor functional tests

### DIFF
--- a/tests/task_streams_test.go
+++ b/tests/task_streams_test.go
@@ -17,8 +17,28 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
+	"testing"
 	"time"
 )
+
+// TestTaskStreaming runs the Task Streaming test suite.
+func TestTaskStreaming(t *testing.T) {
+	ts := &taskStreams{}
+	runTestSuite(t, func(sc *godog.ScenarioContext) {
+		sc.Before(func(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
+			return ctx, ts.setupSuite()
+		})
+		sc.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
+			return ctx, ts.teardownSuite()
+		})
+
+		sc.Step(`^after (\d+) seconds I should receive the same task$`, ts.afterSecondsIShouldReceiveTheSameTask)
+		sc.Step(`^after (\d+) seconds I should receive (\d+) tasks$`, ts.afterSecondsIShouldReceiveTasks)
+		sc.Step(`^I begin streaming after a (\d+) second delay$`, ts.iBeginStreamingAfterASecondDelay)
+		sc.Step(`^I have created the task:$`, ts.iHaveCreatedTheTask)
+	})
+
+}
 
 type taskStreams struct {
 	dbDataDir     string
@@ -219,20 +239,4 @@ func (ts *taskStreams) iHaveCreatedTheTask(arg1 *godog.DocString) error {
 	task, err := ts.client.Push(context.Background(), ts.taskRequest)
 	ts.createdTask = task.GetTask()
 	return err
-}
-
-func InitializeScenario(sc *godog.ScenarioContext) {
-	ts := &taskStreams{}
-
-	sc.Before(func(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
-		return ctx, ts.setupSuite()
-	})
-	sc.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
-		return ctx, ts.teardownSuite()
-	})
-
-	sc.Step(`^after (\d+) seconds I should receive the same task$`, ts.afterSecondsIShouldReceiveTheSameTask)
-	sc.Step(`^after (\d+) seconds I should receive (\d+) tasks$`, ts.afterSecondsIShouldReceiveTasks)
-	sc.Step(`^I begin streaming after a (\d+) second delay$`, ts.iBeginStreamingAfterASecondDelay)
-	sc.Step(`^I have created the task:$`, ts.iHaveCreatedTheTask)
 }

--- a/tests/util/client.go
+++ b/tests/util/client.go
@@ -1,0 +1,148 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"github.com/mlposey/z4/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"io"
+)
+
+// TODO: We should switch to using a public client once one is created.
+// We need to create a Go client that users can import and use for
+// interacting with z4. Once that has been created, we can directly
+// use it in the functional tests rather than this custom client.
+
+// Client is a client for the z4 server.
+type Client struct {
+	conn  *grpc.ClientConn
+	queue proto.QueueClient
+	acks  chan *proto.Ack
+}
+
+func NewClient(host string, port int) (*Client, error) {
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	target := fmt.Sprintf("%s:%d", host, port)
+	conn, err := grpc.Dial(target, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		conn:  conn,
+		queue: proto.NewQueueClient(conn),
+	}, nil
+}
+
+func (c *Client) Push(req *proto.PushTaskRequest) (*proto.PushTaskResponse, error) {
+	return c.queue.Push(context.Background(), req)
+}
+
+func (c *Client) PullTasks(requestID, namespace string) (*PullTasksStream, error) {
+	return newPullTasksStream(c.queue, requestID, namespace)
+}
+
+// Close closes the connection to the server.
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
+type PullTasksStream struct {
+	stream    proto.Queue_PullClient
+	results   chan StreamTaskResult
+	acks      chan *proto.Ack
+	namespace string
+	requestID string
+	closed    bool
+}
+
+func newPullTasksStream(queue proto.QueueClient, requestID, namespace string) (*PullTasksStream, error) {
+	stream, err := queue.Pull(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	return &PullTasksStream{
+		stream:    stream,
+		acks:      make(chan *proto.Ack),
+		namespace: namespace,
+		requestID: requestID,
+	}, nil
+}
+
+func (s *PullTasksStream) Close() error {
+	s.closed = true
+	return nil
+}
+
+func (s *PullTasksStream) Listen() (<-chan StreamTaskResult, error) {
+	if s.results != nil {
+		return s.results, nil
+	}
+	s.results = make(chan StreamTaskResult)
+
+	err := s.startStream()
+	if err != nil {
+		return nil, err
+	}
+	go s.startAckHandler()
+	return s.results, nil
+}
+
+func (s *PullTasksStream) startStream() error {
+	err := s.stream.Send(&proto.PullRequest{
+		Request: &proto.PullRequest_StartReq{
+			StartReq: &proto.StartStreamRequest{
+				RequestId: s.requestID,
+				Namespace: s.namespace,
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for !s.closed {
+			task, err := s.stream.Recv()
+			s.results <- StreamTaskResult{
+				Error: err,
+				Task:  task,
+				acks:  s.acks,
+			}
+
+			if err == io.EOF {
+				break
+			}
+		}
+	}()
+	return nil
+}
+
+func (s *PullTasksStream) startAckHandler() {
+	for ack := range s.acks {
+		err := s.stream.Send(&proto.PullRequest{
+			Request: &proto.PullRequest_Ack{
+				Ack: ack,
+			},
+		})
+
+		if err != nil {
+			fmt.Println("ack failed", err)
+		}
+	}
+}
+
+type StreamTaskResult struct {
+	Error error
+	Task  *proto.Task
+	acks  chan<- *proto.Ack
+}
+
+func (str StreamTaskResult) Ack() {
+	str.acks <- &proto.Ack{
+		Namespace: str.Task.GetNamespace(),
+		TaskId:    str.Task.GetId(),
+	}
+}

--- a/tests/util/local.go
+++ b/tests/util/local.go
@@ -1,0 +1,112 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+	"github.com/segmentio/ksuid"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// LocalServer manages a local instance of a z4 server.
+type LocalServer struct {
+	dbDataDir   string
+	peerDataDir string
+	server      *os.Process
+	serverPort  int
+	appOutput   io.ReadCloser
+	appHandle   *exec.Cmd
+}
+
+func NewLocalServer(port int) *LocalServer {
+	return &LocalServer{
+		dbDataDir:   "/tmp/" + ksuid.New().String(),
+		peerDataDir: "/tmp/" + ksuid.New().String(),
+		serverPort:  port,
+	}
+}
+
+// Start starts the application in a background process.
+func (ls *LocalServer) Start() error {
+	if err := ls.startApp(); err != nil {
+		return err
+	}
+	return ls.waitForInit()
+}
+
+// starts the application in a new process
+func (ls *LocalServer) startApp() error {
+	_ = os.Setenv("Z4_DB_DATA_DIR", ls.dbDataDir)
+	_ = os.Setenv("Z4_SERVICE_PORT", fmt.Sprint(ls.serverPort))
+	_ = os.Setenv("Z4_DEBUG_LOGGING_ENABLED", "true")
+	_ = os.Setenv("Z4_PEER_ID", "godog")
+	_ = os.Setenv("Z4_BOOTSTRAP_CLUSTER", "true")
+	_ = os.Setenv("Z4_PEER_DATA_DIR", ls.peerDataDir)
+
+	ls.appHandle = exec.Command("bash", "-c", "go run ../cmd/server/*.go")
+
+	// used get print logs later on in this method
+	stdout, err := ls.appHandle.StdoutPipe()
+	ls.appHandle.Stderr = ls.appHandle.Stdout
+	if err != nil {
+		return err
+	}
+	ls.appOutput = stdout
+
+	// helpful for killing the server / child process
+	// essentially assigns all processes we spawn to this group; we will later
+	// kill the entire group at one time
+	ls.appHandle.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	return ls.appHandle.Start()
+}
+
+// waits for the application to finish startup
+func (ls *LocalServer) waitForInit() error {
+	ready := make(chan bool)
+	go func() {
+		// Read the app output until we think it is ready for connections.
+		// TODO: Use the health check endpoint instead.
+		for {
+			tmp := make([]byte, 1024)
+			_, e := ls.appOutput.Read(tmp)
+			fmt.Print("[server]: " + string(tmp))
+			if e != nil {
+				break
+			}
+
+			if strings.Contains(string(tmp), "entering leader state") {
+				ready <- true
+			}
+		}
+	}()
+
+	select {
+	case <-ready:
+		time.Sleep(time.Millisecond * 100)
+	case <-time.NewTimer(time.Second * 30).C:
+		return errors.New("server not started before deadline")
+	}
+
+	ls.server = ls.appHandle.Process
+	return nil
+}
+
+// Stop tears down the application.
+func (ls *LocalServer) Stop() error {
+	if ls.server == nil {
+		fmt.Println("cannot stop server: not started")
+		return nil
+	}
+
+	err := syscall.Kill(-ls.server.Pid, syscall.SIGKILL)
+	if err != nil {
+		return err
+	}
+	_, err = ls.server.Wait()
+	return err
+}

--- a/tests/z4_test.go
+++ b/tests/z4_test.go
@@ -1,0 +1,24 @@
+package tests
+
+import (
+	"github.com/cucumber/godog"
+	"testing"
+)
+
+func runTestSuite(t *testing.T, init func(s *godog.ScenarioContext)) {
+	suite := godog.TestSuite{
+		ScenarioInitializer: init,
+		Options: &godog.Options{
+			Format:        "pretty",
+			Paths:         []string{"features"},
+			TestingT:      t,
+			Randomize:     -1,
+			StopOnFailure: true,
+			Strict:        true,
+		},
+	}
+
+	if suite.Run() != 0 {
+		t.Fatal("non-zero status returned, failed to run feature tests")
+	}
+}


### PR DESCRIPTION
This MR pulls common server/client logic out of the test suite for task streaming and adds it to a utility package. This will make it easy to create more tests later because the logic can be reused.