### PR TITLE
Cache logs for raft pipelining

### DIFF
--- a/server/cluster/peer.go
+++ b/server/cluster/peer.go
@@ -65,7 +65,7 @@ func (p *Peer) initStorage() error {
 		}
 	}
 
-	p.logStore, err = raftutil.NewLogStore(p.config.DB.DB, p.config.LogBatchSize)
+	p.logStore, err = raftutil.NewLogStore(p.config.DB.DB)
 	if err != nil {
 		return fmt.Errorf("failed to load log store: %w", err)
 	}

--- a/storage/raftutil/cache.go
+++ b/storage/raftutil/cache.go
@@ -46,13 +46,16 @@ func (p *logCache) Remove(index uint64) {
 func (p *logCache) load(index uint64) (marshaledLog, error) {
 	// TODO: Record cache misses using a metric.
 	var log marshaledLog
-	return log, p.db.View(func(txn *badger.Txn) error {
+	err := p.db.View(func(txn *badger.Txn) error {
 		item, err := txn.Get(getLogKey(index))
 		if err != nil {
 			return err
 		}
 
-		log, err = item.ValueCopy(nil)
-		return err
+		return item.Value(func(val []byte) error {
+			log = val
+			return nil
+		})
 	})
+	return log, err
 }

--- a/storage/raftutil/log.go
+++ b/storage/raftutil/log.go
@@ -10,8 +10,9 @@ import (
 )
 
 type BadgerLogStore struct {
-	db    *badger.DB
-	cache *logCache
+	db              *badger.DB
+	cache           *logCache
+	maxCompactedIdx uint64
 }
 
 var _ raft.LogStore = (*BadgerLogStore)(nil)
@@ -29,7 +30,7 @@ func NewLogStore(db *badger.DB) (*BadgerLogStore, error) {
 
 func (b *BadgerLogStore) FirstIndex() (uint64, error) {
 	var index uint64
-	return index, b.db.View(func(txn *badger.Txn) error {
+	err := b.db.View(func(txn *badger.Txn) error {
 		opts := badger.DefaultIteratorOptions
 		opts.PrefetchValues = false
 		opts.Prefix = logStorePrefix
@@ -46,6 +47,45 @@ func (b *BadgerLogStore) FirstIndex() (uint64, error) {
 		index = binary.BigEndian.Uint64(idx)
 		return nil
 	})
+	if err != nil {
+		return 0, err
+	}
+
+	if index < b.maxCompactedIdx {
+		// TODO: Properly fix FirstIndex compaction bug.
+		// This is technically a fix, but it is more of a workaround.
+
+		// This block handles a weird but reproducible bug that
+		// I don't quite understand.
+		//
+		// When the Raft log becomes large enough, it is compacted.
+		// Compaction involves a few steps
+		// 1. Take a snapshot of the finite state machine (aka the
+		//    task database).
+		// 2. Select the first N logs for deletion.
+		//    Example:
+		//      N = 1000
+		//      First log has index 50
+		//      The following indexes are selected (inclusive): [50, 1050]
+		// 3. Use the DeleteRange method of the LogStore to actually
+		//    perform the log deletions. Once this is complete, the
+		//    first log will change to be the last compacted log plus one.
+		//
+		// It has been observed that, after log compaction, the FirstIndex
+		// method of the LogStore occasionally returns an index that has
+		// recently been compacted. I.e., it used to be the first index
+		// but is now outdated and references a log that does not exist.
+		//
+		// When FirstIndex returns an invalid index, the GetLog method
+		// will be invoked with that index and return an error. Raft will
+		// infinitely retry GetLog if it returns an error.
+		//
+		// So this code is essentially overruling what BadgerDB thinks
+		// is the first index based on what we know about the compaction
+		// process. This helps us avoid infinite loops in the Raft algorithm.
+		index = b.maxCompactedIdx + 1
+	}
+	return index, nil
 }
 
 func (b *BadgerLogStore) LastIndex() (uint64, error) {
@@ -123,6 +163,7 @@ func (b *BadgerLogStore) DeleteRange(min, max uint64) error {
 		}
 		b.cache.Remove(i)
 	}
+	b.maxCompactedIdx = max
 	return batch.Flush()
 }
 


### PR DESCRIPTION
The largest consumer of CPU time during load tests is the Get operation on the BadgerLogStore during log replication to followers. There is no need to check the disk for that call because we can cache the logs during the Set operations.